### PR TITLE
Bugfix/kasm 1912 websocket crash

### DIFF
--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -1024,7 +1024,7 @@ PixelBuffer *rfb::progressiveBilinearScale(const PixelBuffer *pb,
       rdr::U8 *newpx = ((ManagedPixelBuffer *) newpb)->getBufferRW(newpb->getRect(),
                                                                    &newstride);
 
-      SSE2_scale(oldpx, tgtw, tgth, newpx, oldstride, newstride, tgtdiff);
+      SSE2_scale(oldpx, tgtw, tgth, newpx, oldstride, newstride, tgtw / (float) oldw);
       if (del)
         delete pb;
     }


### PR DESCRIPTION
Fixes progressive bilinear artifacts when in scaling video mode. Tested all scaling algos on different resolutions. Fixes websocket crash on large data transfers.