### PR TITLE
KASM-1871 Add smooth scrolling

### DIFF
--- a/common/rfb/InputHandler.h
+++ b/common/rfb/InputHandler.h
@@ -38,7 +38,9 @@ namespace rfb {
     virtual void pointerEvent(const Point& __unused_attr pos,
 		              int __unused_attr buttonMask,
                               const bool __unused_attr skipClick,
-                              const bool __unused_attr skipRelease) { }
+                              const bool __unused_attr skipRelease,
+                              int scrollX,
+                              int scrollY) { }
     virtual void clientCutText(const char* __unused_attr str,
                                int __unused_attr len) { }
   };

--- a/common/rfb/SMsgReader.cxx
+++ b/common/rfb/SMsgReader.cxx
@@ -223,7 +223,9 @@ void SMsgReader::readPointerEvent()
   int mask = is->readU8();
   int x = is->readU16();
   int y = is->readU16();
-  handler->pointerEvent(Point(x, y), mask, false, false);
+  int scrollX = is->readS16();
+  int scrollY = is->readS16();
+  handler->pointerEvent(Point(x, y), mask, false, false, scrollX, scrollY);
 }
 
 

--- a/common/rfb/VNCSConnectionST.cxx
+++ b/common/rfb/VNCSConnectionST.cxx
@@ -692,7 +692,7 @@ void VNCSConnectionST::setPixelFormat(const PixelFormat& pf)
   setCursor();
 }
 
-void VNCSConnectionST::pointerEvent(const Point& pos, int buttonMask, const bool skipClick, const bool skipRelease)
+void VNCSConnectionST::pointerEvent(const Point& pos, int buttonMask, const bool skipClick, const bool skipRelease, int scrollX, int scrollY)
 {
   pointerEventTime = lastEventTime = time(0);
   server->lastUserInputTime = lastEventTime;
@@ -720,7 +720,7 @@ void VNCSConnectionST::pointerEvent(const Point& pos, int buttonMask, const bool
       }
     }
 
-    server->desktop->pointerEvent(pointerEventPos, buttonMask, skipclick, skiprelease);
+    server->desktop->pointerEvent(pointerEventPos, buttonMask, skipclick, skiprelease, scrollX, scrollY);
   }
 }
 

--- a/common/rfb/VNCSConnectionST.h
+++ b/common/rfb/VNCSConnectionST.h
@@ -204,7 +204,7 @@ namespace rfb {
     virtual void queryConnection(const char* userName);
     virtual void clientInit(bool shared);
     virtual void setPixelFormat(const PixelFormat& pf);
-    virtual void pointerEvent(const Point& pos, int buttonMask, const bool skipClick, const bool skipRelease);
+    virtual void pointerEvent(const Point& pos, int buttonMask, const bool skipClick, const bool skipRelease, int scrollX, int scrollY);
     virtual void keyEvent(rdr::U32 keysym, rdr::U32 keycode, bool down);
     virtual void framebufferUpdateRequest(const Rect& r, bool incremental);
     virtual void setDesktopSize(int fb_width, int fb_height,

--- a/unix/xserver/hw/vnc/Input.h
+++ b/unix/xserver/hw/vnc/Input.h
@@ -35,6 +35,7 @@ void vncInitInputDevice(void);
 void vncPointerButtonAction(int buttonMask, const unsigned char skipclick,
                             const unsigned char skiprelease);
 void vncPointerMove(int x, int y);
+void vncScroll(int x, int y);
 void vncGetPointerPos(int *x, int *y);
 
 void vncKeyboardEvent(KeySym keysym, unsigned xtcode, int down);

--- a/unix/xserver/hw/vnc/XserverDesktop.cc
+++ b/unix/xserver/hw/vnc/XserverDesktop.cc
@@ -446,11 +446,14 @@ void XserverDesktop::approveConnection(uint32_t opaqueId, bool accept,
 
 
 void XserverDesktop::pointerEvent(const Point& pos, int buttonMask,
-                                  const bool skipClick, const bool skipRelease)
+                                  const bool skipClick, const bool skipRelease, int scrollX, int scrollY)
 {
-  vncPointerMove(pos.x + vncGetScreenX(screenIndex),
-                 pos.y + vncGetScreenY(screenIndex));
-  vncPointerButtonAction(buttonMask, skipClick, skipRelease);
+  if (scrollX == 0 && scrollY == 0) {
+    vncPointerMove(pos.x + vncGetScreenX(screenIndex), pos.y + vncGetScreenY(screenIndex));
+    vncPointerButtonAction(buttonMask, skipClick, skipRelease);
+  } else {
+    vncScroll(scrollX, scrollY);
+  }
 }
 
 unsigned int XserverDesktop::setScreenLayout(int fb_width, int fb_height,

--- a/unix/xserver/hw/vnc/XserverDesktop.h
+++ b/unix/xserver/hw/vnc/XserverDesktop.h
@@ -90,7 +90,7 @@ public:
 
   // rfb::SDesktop callbacks
   virtual void pointerEvent(const rfb::Point& pos, int buttonMask,
-                            const bool skipClick, const bool skipRelease);
+                            const bool skipClick, const bool skipRelease, int scrollX = 0, int scrollY = 0);
   virtual void keyEvent(rdr::U32 keysym, rdr::U32 keycode, bool down);
   virtual unsigned int setScreenLayout(int fb_width, int fb_height,
                                        const rfb::ScreenSet& layout);


### PR DESCRIPTION
Previously all scrolling relied on "clicking" the up/down or left/right scroll buttons
which made it imprecise and to always scroll at the same speed.

Now we pass the scroll delta directly to the xorg input driver so the scroll is more responsive and adaptive.