### PR TITLE
Fix a nonexistent username + empty password passing through

### DIFF
--- a/common/network/websocket.c
+++ b/common/network/websocket.c
@@ -1320,6 +1320,8 @@ ws_ctx_t *do_handshake(int sock) {
             } else {
                 // Client tried an empty password, just fail them
                 response[0] = '\0';
+                authbuf[0] = 'a';
+                authbuf[1] = '\0';
             }
         }
 


### PR DESCRIPTION
Tested and confirmed this fixes the issue of a blank password providing RO access. Additionally tested sending extremely long passwords and usernames, this results the server sending a blank response instead of a 401, the server side logs that the request had an invalid auth header.