### PR TITLE
Add bump-package-version(1) and document it

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -79,6 +79,25 @@ packages installed with XFCE.
 ```
 builder/test-deb-barebones ubuntu focal
 ```
+
+# Preparing a release
+
+Deb and rpm packages need their versions bumped to the new release version. It
+can be done with:
+
+```
+builder/bump-package-version 0.9.4-beta
+```
+
+This will update corresponding package files, use `git diff` to see changes.
+
+If you've ran the command and curious about Debian version specifics, here's an
+explanation:
+Deb version will be `0.9.4~beta-1`. `~` (and not `-`) is required by packaging
+guidelines, and `-1` is Debian package revision for `0.9.4` upstream release. If
+a Debian-specific patch was later added on top of `0.9.4`, it'd be `-2` for the
+next Debian version. Rpm has a corresponding revision in its .spec file.
+
 # CI development
 
 S3 upload code is extracted to various files in `.ci`. It's possible to iterate

--- a/builder/bump-package-version
+++ b/builder/bump-package-version
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+update_version_to_meet_packaging_standards() {
+  new_version=$(echo "$new_version" |
+    sed -e 's/\([0-9]\)-\([a-zA-Z]\)/\1~\2/')
+}
+
+add_debian_revision_to_new_version() {
+  echo "$new_version-1"
+}
+
+bump_rpm() {
+  sed -i "s/^Version:.\+/Version:        $new_version/" centos/kasmvncserver.spec
+}
+
+bump_deb() {
+  local image="debbump_package_version:dev"
+  local L_UID=$(id -u)
+  local L_GID=$(id -g)
+  local debian_version=$(add_debian_revision_to_new_version)
+
+  docker build -t "$image" -f builder/dockerfile.bump-package-version .
+  docker run --rm -v "$PWD":/src --user "$L_UID:$L_GID" \
+    "$image" /bin/bash -c \
+    "cd /src && builder/bump-package-version-inside-docker-deb $debian_version"
+}
+
+new_version="$1"
+
+if [[ -z "$new_version" ]]; then
+  echo >&2 "Usage: $(basename "$0") <new_version>"
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+update_version_to_meet_packaging_standards
+bump_rpm
+bump_deb

--- a/builder/bump-package-version-inside-docker-deb
+++ b/builder/bump-package-version-inside-docker-deb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+new_version="$1"
+
+update_version() {
+  dch --newversion $new_version 'New upstream release.'
+}
+
+mark_as_released() {
+  dch --release ""
+}
+
+update_version
+mark_as_released

--- a/builder/dockerfile.bump-package-version
+++ b/builder/dockerfile.bump-package-version
@@ -1,0 +1,6 @@
+FROM debian:buster
+
+ENV DEBEMAIL="Kasm Technologies LLC <info@kasmweb.com>"
+
+RUN apt-get update && \
+      apt-get -y install vim devscripts


### PR DESCRIPTION
This automates deb and rpm version bumping by providing a command to do so.