### PR TITLE
[FIX] Second Typo in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo addgroup $USER ssl-cert
 # You will need to re-connect in order to pick up the group change
 
 # Create a KasmVNC user able to use keyboard and mouse:
-vncpasswd -u $USER -w
+kasmvncpasswd -u $USER -w
 
 # Create ~/.vnc directory and corresponding files.
 kasmvncserver-easy-start -d && kasmvncserver-easy-start -kill


### PR DESCRIPTION
@ledestin ReadMe references the wrong `vncpasswd` command; I think it should read `kasmvncpasswd` (at least, this is the only version that worked for me).