### PR TITLE
Ubuntu Noble

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,6 +180,44 @@ build_ubuntu_jammy_arm:
     paths:
       - output/
 
+build_ubuntu_noble:
+  stage: build
+  allow_failure: true
+  tags:
+    - oci-fixed-amd
+  before_script:
+    - *prepare_build
+    - *prepare_www
+  after_script:
+    - *prepare_artfacts
+  script:
+    - bash builder/build-package ubuntu noble;
+  only:
+    variables:
+      - $BUILD_JOBS == 'all' || $BUILD_JOBS =~ $CI_JOB_NAME
+  artifacts:
+    paths:
+      - output/
+
+build_ubuntu_noble_arm:
+  stage: build
+  allow_failure: true
+  tags:
+    - oci-fixed-arm
+  before_script:
+    - *prepare_build
+    - *prepare_www
+  after_script:
+    - *prepare_artfacts
+  script:
+    - bash builder/build-package ubuntu noble;
+  only:
+    variables:
+      - $BUILD_JOBS == 'all' || $BUILD_JOBS =~ $CI_JOB_NAME
+  artifacts:
+    paths:
+      - output/
+
 build_debian_buster:
   stage: build
   allow_failure: true

--- a/builder/dockerfile.ubuntu_noble.build
+++ b/builder/dockerfile.ubuntu_noble.build
@@ -1,0 +1,31 @@
+FROM ubuntu:noble
+
+ENV KASMVNC_BUILD_OS ubuntu
+ENV KASMVNC_BUILD_OS_CODENAME noble
+ENV XORG_VER 1.20.14
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN sed -i 's$Types: deb$Types: deb deb-src$' /etc/apt/sources.list.d/ubuntu.sources
+
+RUN apt-get update && \
+      apt-get -y install sudo
+
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata
+RUN apt-get update && apt-get -y build-dep xorg-server libxfont-dev
+RUN apt-get update && apt-get -y install cmake git libgnutls28-dev vim wget tightvncserver curl
+RUN apt-get update && apt-get -y install libpng-dev libtiff-dev libgif-dev libavcodec-dev libssl-dev libxrandr-dev libxcursor-dev
+
+ENV SCRIPTS_DIR=/tmp/scripts
+COPY builder/scripts $SCRIPTS_DIR
+RUN $SCRIPTS_DIR/build-webp
+RUN $SCRIPTS_DIR/build-libjpeg-turbo
+
+RUN userdel -f -r ubuntu \
+  && rm -rf /home/ubuntu
+
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+
+COPY --chown=docker:docker . /src/
+
+USER docker
+ENTRYPOINT ["/src/builder/build.sh"]

--- a/builder/dockerfile.ubuntu_noble.deb.build
+++ b/builder/dockerfile.ubuntu_noble.deb.build
@@ -1,0 +1,22 @@
+FROM ubuntu:noble
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+      apt-get -y install vim build-essential devscripts equivs
+
+# Install build-deps for the package.
+COPY ./debian/control /tmp
+RUN apt-get update && echo YYY | mk-build-deps --install --remove /tmp/control
+
+RUN userdel -f -r ubuntu \
+  && rm -rf /home/ubuntu
+ 
+ARG L_UID
+RUN if [ "$L_UID" -eq 0 ]; then \
+      useradd -m docker; \
+    else \
+      useradd -m docker -u $L_UID;\
+    fi
+
+USER docker

--- a/builder/dockerfile.ubuntu_noble.deb.test
+++ b/builder/dockerfile.ubuntu_noble.deb.test
@@ -1,0 +1,60 @@
+FROM ubuntu:noble
+
+ENV DISPLAY=:1 \
+    VNC_PORT=8443 \
+    VNC_RESOLUTION=1280x720 \
+    MAX_FRAME_RATE=24 \
+    VNCOPTIONS="-PreferBandwidth -DynamicQualityMin=4 -DynamicQualityMax=7" \
+    HOME=/home/user \
+    TERM=xterm \
+    STARTUPDIR=/dockerstartup \
+    INST_SCRIPTS=/dockerstartup/install \
+    KASM_RX_HOME=/dockerstartup/kasmrx \
+    DEBIAN_FRONTEND=noninteractive \
+    VNC_COL_DEPTH=24 \
+    VNC_RESOLUTION=1280x1024 \
+    VNC_PW=vncpassword \
+    VNC_USER=user \
+    VNC_VIEW_ONLY_PW=vncviewonlypassword \
+    LD_LIBRARY_PATH=/usr/local/lib/ \
+    OMP_WAIT_POLICY=PASSIVE \
+    SHELL=/bin/bash \
+    SINGLE_APPLICATION=0 \
+    KASMVNC_BUILD_OS=ubuntu \
+    KASMVNC_BUILD_OS_CODENAME=noble
+
+EXPOSE $VNC_PORT
+
+WORKDIR $HOME
+
+### REQUIRED STUFF ###
+
+RUN userdel -f -r ubuntu \
+  && rm -rf /home/ubuntu
+
+RUN apt-get update && apt-get install -y supervisor xfce4 xfce4-terminal xterm libnss-wrapper gettext wget dbus dbus-x11
+RUN apt-get purge -y pm-utils xscreensaver*
+RUN apt-get update && apt-get install -y vim less
+RUN apt-get update && apt-get -y install lsb-release
+
+RUN echo 'source $STARTUPDIR/generate_container_user' >> $HOME/.bashrc
+
+RUN mkdir -p $STARTUPDIR
+COPY builder/startup/ $STARTUPDIR
+
+### START CUSTOM STUFF ####
+
+ARG KASMVNC_PACKAGE_DIR
+COPY $KASMVNC_PACKAGE_DIR/kasmvncserver_*.deb /tmp/
+RUN rm -f /tmp/kasmvncserver_*+*.deb; dpkg -i /tmp/*.deb; apt-get -yf install
+
+RUN mkdir ~/.vnc && echo '/usr/bin/xfce4-session &' >> ~/.vnc/xstartup && \
+  chmod +x ~/.vnc/xstartup
+
+### END CUSTOM STUFF ###
+
+RUN chown -R 1000:0 $HOME
+USER 1000:ssl-cert
+WORKDIR $HOME
+
+ENTRYPOINT [ "/dockerstartup/vnc_startup.sh" ]

--- a/builder/dockerfile.ubuntu_noble.test
+++ b/builder/dockerfile.ubuntu_noble.test
@@ -1,0 +1,54 @@
+FROM ubuntu:noble
+
+ENV DISPLAY=:1 \
+    VNC_PORT=8443 \
+    VNC_RESOLUTION=1280x720 \
+    MAX_FRAME_RATE=24 \
+    VNCOPTIONS="-PreferBandwidth -DynamicQualityMin=4 -DynamicQualityMax=7" \
+    HOME=/home/user \
+    TERM=xterm \
+    STARTUPDIR=/dockerstartup \
+    INST_SCRIPTS=/dockerstartup/install \
+    KASM_RX_HOME=/dockerstartup/kasmrx \
+    DEBIAN_FRONTEND=noninteractive \
+    VNC_COL_DEPTH=24 \
+    VNC_RESOLUTION=1280x1024 \
+    VNC_PW=vncpassword \
+    VNC_USER=user \
+    VNC_VIEW_ONLY_PW=vncviewonlypassword \
+    LD_LIBRARY_PATH=/usr/local/lib/ \
+    OMP_WAIT_POLICY=PASSIVE \
+    SHELL=/bin/bash \
+    SINGLE_APPLICATION=0 \
+    KASMVNC_BUILD_OS=ubuntu \
+    KASMVNC_BUILD_OS_CODENAME=noble
+
+EXPOSE $VNC_PORT
+
+WORKDIR $HOME
+
+### REQUIRED STUFF ###
+
+RUN userdel -f -r ubuntu \
+  && rm -rf /home/ubuntu
+
+RUN apt-get update && apt-get install -y supervisor xfce4 xfce4-terminal xterm libnss-wrapper gettext dbus dbus-x11
+RUN apt-get purge -y pm-utils xscreensaver*
+
+RUN echo 'source $STARTUPDIR/generate_container_user' >> $HOME/.bashrc
+
+RUN mkdir -p $STARTUPDIR
+COPY startup/ $STARTUPDIR
+
+### START CUSTOM STUFF ####
+
+COPY build/kasmvnc.${KASMVNC_BUILD_OS}_${KASMVNC_BUILD_OS_CODENAME}.tar.gz /tmp/
+RUN tar -xzvf /tmp/kasmvnc.${KASMVNC_BUILD_OS}_${KASMVNC_BUILD_OS_CODENAME}.tar.gz --strip 1 -C /
+
+### END CUSTOM STUFF ###
+
+RUN chown -R 1000:0 $HOME
+USER 1000
+WORKDIR $HOME
+
+ENTRYPOINT [ "/dockerstartup/vnc_startup.sh" ]

--- a/builder/test-deb
+++ b/builder/test-deb
@@ -17,7 +17,6 @@ docker run -it -p "443:$VNC_PORT" --rm \
   -e KASMVNC_VERBOSE_LOGGING=$KASMVNC_VERBOSE_LOGGING \
   -e "VNC_USER=foo" -e "VNC_PW=foobar" \
   -e "VNC_PORT=$VNC_PORT" \
-  --security-opt seccomp=unconfined \
   $entrypoint_executable \
   "$tester_image" \
   $entrypoint_args

--- a/builder/test-deb
+++ b/builder/test-deb
@@ -17,6 +17,7 @@ docker run -it -p "443:$VNC_PORT" --rm \
   -e KASMVNC_VERBOSE_LOGGING=$KASMVNC_VERBOSE_LOGGING \
   -e "VNC_USER=foo" -e "VNC_PW=foobar" \
   -e "VNC_PORT=$VNC_PORT" \
+  --security-opt seccomp=unconfined \
   $entrypoint_executable \
   "$tester_image" \
   $entrypoint_args


### PR DESCRIPTION
Steps to test:

```
git submodule update --remote --init
./builder/test-deb ubuntu noble
```

Implements packaging for Ubuntu 24.04


Changes compared to the Ubuntu Jammy image:
- Use the new [deb822 format](https://repolib.readthedocs.io/en/latest/deb822-format.html) used in Ubuntu 24.04, sed expression is adjusted
- Install **dbus** and **dbus-x11** in the test image
- Remove default **ubuntu** user from container image which has user id 1000


The problem mentioned before with **seccomp** is only with Docker 24, not on Docker 20.10, tested on Debian Bullseye on GitHub Codespaces.

`docker run --rm -it --shm-size=512m -p 6901:6901 -e VNC_PW=password kasmweb/firefox:1.14.0` on Docker 24 on Debian Bullseye:
```
** (xfdesktop:324): WARNING **: 13:32:33.023: Failed to get system bus: Could not connect: No such file or directory
 2024-04-26 13:32:33,012 [DEBUG] Selection: Selection owner change for XFDESKTOP_SELECTION_0
 2024-04-26 13:32:33,012 [DEBUG] Selection: Selection owner change for _NET_DESKTOP_MANAGER_S0

(xfce4-session:87): xfce4-session-WARNING **: 13:32:40.680: Unable to launch "system-config-printer-applet" (specified by autostart/print-applet.desktop): Failed to execute child process “system-config-printer-applet” (No such file or directory)

** (xiccd:523): CRITICAL **: 13:32:40.867: Failed to connect to colord: Could not connect: No such file or directory
```