### PR TITLE
Add build for Devuan Excalibur

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,7 @@ build_amd64:
       - output/
   parallel:
     matrix:
-      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
+      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'devuan excalibur', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
 
 build_arm64:
   stage: build
@@ -144,7 +144,7 @@ build_arm64:
       - output/
   parallel:
     matrix:
-      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
+      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'devuan excalibur', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
 
 run_test_amd64:
   stage: run_test
@@ -173,7 +173,7 @@ run_test_amd64:
         - run_test/*.xml
   parallel:
     matrix:
-      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
+      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'devuan excalibur', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
 
 run_test_arm64:
   stage: run_test
@@ -203,7 +203,7 @@ run_test_arm64:
         - run_test/*.xml
   parallel:
     matrix:
-      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
+      - DISTRO: [ 'ubuntu focal', 'ubuntu jammy', 'ubuntu noble', 'debian bullseye', 'debian bookworm', 'debian trixie', 'devuan excalibur', 'kali kali-rolling', 'oracle 8', 'oracle 9', 'opensuse 15', 'fedora forty', 'fedora fortyone', 'alpine 318', 'alpine 319', 'alpine 320', 'alpine 321' ]
 
 spec_test:
   stage: test

--- a/builder/dockerfile.devuan_excalibur.barebones.deb.test
+++ b/builder/dockerfile.devuan_excalibur.barebones.deb.test
@@ -1,0 +1,1 @@
+dockerfile.debian.barebones.deb.test

--- a/builder/dockerfile.devuan_excalibur.build
+++ b/builder/dockerfile.devuan_excalibur.build
@@ -1,0 +1,39 @@
+FROM devuan/devuan:excalibur
+
+ENV KASMVNC_BUILD_OS devuan
+ENV KASMVNC_BUILD_OS_CODENAME excalibur
+ENV XORG_VER 21.1.16
+ENV DEBIAN_FRONTEND noninteractive
+
+# Upstream bug workaround
+# Ref: https://dev1galaxy.org/viewtopic.php?pid=59263
+RUN chmod o-w /usr/sbin
+
+RUN \
+  echo "**** add all sources ****" && \
+  echo "deb http://deb.devuan.org/merged excalibur main contrib non-free non-free-firmware" > /etc/apt/sources.list && \
+  echo "deb-src http://deb.devuan.org/merged excalibur main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+  echo "deb http://deb.devuan.org/merged excalibur-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+  echo "deb-src http://deb.devuan.org/merged excalibur-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+  echo "deb http://deb.devuan.org/merged excalibur-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+  echo "deb-src http://deb.devuan.org/merged excalibur-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list
+
+RUN apt-get update && \
+      apt-get -y install sudo
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+RUN apt-get update && apt-get -y build-dep xorg-server libxfont-dev
+RUN apt-get update && apt-get -y install ninja-build cmake nasm git libgnutls28-dev vim wget tightvncserver curl
+RUN apt-get update && apt-get -y install libpng-dev libtiff-dev libgif-dev libavcodec-dev libssl-dev libxrandr-dev \
+    libxcursor-dev libavformat-dev libswscale-dev
+
+ENV SCRIPTS_DIR=/tmp/scripts
+COPY builder/scripts $SCRIPTS_DIR
+RUN $SCRIPTS_DIR/build-deps.sh
+
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+
+COPY --chown=docker:docker . /src/
+
+USER docker
+ENTRYPOINT ["/src/builder/build.sh"]

--- a/builder/dockerfile.devuan_excalibur.deb.build
+++ b/builder/dockerfile.devuan_excalibur.deb.build
@@ -1,0 +1,23 @@
+FROM devuan/devuan:excalibur
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Upstream bug workaround
+# Ref: https://dev1galaxy.org/viewtopic.php?pid=59263
+RUN chmod o-w /usr/sbin
+
+RUN apt-get update && \
+      apt-get -y install vim build-essential devscripts equivs
+
+# Install build-deps for the package.
+COPY ./debian/control /tmp
+RUN apt-get update && echo YYY | mk-build-deps --install --remove /tmp/control
+
+ARG L_UID
+RUN if [ "$L_UID" -eq 0 ]; then \
+      useradd -m docker; \
+    else \
+      useradd -m docker -u $L_UID;\
+    fi
+
+USER docker

--- a/builder/dockerfile.devuan_excalibur.deb.test
+++ b/builder/dockerfile.devuan_excalibur.deb.test
@@ -1,0 +1,61 @@
+FROM devuan/devuan:excalibur
+
+# Upstream bug workaround
+# Ref: https://dev1galaxy.org/viewtopic.php?pid=59263
+RUN chmod o-w /usr/sbin
+
+ENV DISPLAY=:1 \
+    VNC_PORT=8443 \
+    VNC_RESOLUTION=1280x720 \
+    MAX_FRAME_RATE=24 \
+    VNCOPTIONS="-PreferBandwidth -DynamicQualityMin=4 -DynamicQualityMax=7" \
+    HOME=/home/user \
+    TERM=xterm \
+    STARTUPDIR=/dockerstartup \
+    INST_SCRIPTS=/dockerstartup/install \
+    KASM_RX_HOME=/dockerstartup/kasmrx \
+    DEBIAN_FRONTEND=noninteractive \
+    VNC_COL_DEPTH=24 \
+    VNC_RESOLUTION=1280x1024 \
+    VNC_PW=vncpassword \
+    VNC_USER=user \
+    VNC_VIEW_ONLY_PW=vncviewonlypassword \
+    LD_LIBRARY_PATH=/usr/local/lib/ \
+    OMP_WAIT_POLICY=PASSIVE \
+    SHELL=/bin/bash \
+    SINGLE_APPLICATION=0 \
+    KASMVNC_BUILD_OS=devuan \
+    KASMVNC_BUILD_OS_CODENAME=excalibur
+
+EXPOSE $VNC_PORT
+
+WORKDIR $HOME
+
+### REQUIRED STUFF ###
+
+RUN apt-get update && apt-get install -y supervisor xfce4 xfce4-terminal dbus-x11 xterm libnss-wrapper gettext wget
+RUN apt-get purge -y pm-utils xscreensaver*
+RUN apt-get update && apt-get install -y vim less
+RUN apt-get update && apt-get -y install lsb-release
+
+RUN echo 'source $STARTUPDIR/generate_container_user' >> $HOME/.bashrc
+
+RUN mkdir -p $STARTUPDIR
+COPY builder/startup/ $STARTUPDIR
+
+### START CUSTOM STUFF ####
+
+COPY ./builder/scripts/ /tmp/scripts/
+COPY ./debian/changelog /tmp
+
+ARG KASMVNC_PACKAGE_DIR
+COPY $KASMVNC_PACKAGE_DIR/kasmvncserver_*.deb /tmp/
+RUN /tmp/scripts/install_kasmvncserver_package
+
+### END CUSTOM STUFF ###
+
+RUN chown -R 1000:0 $HOME
+USER 1000:ssl-cert
+WORKDIR $HOME
+
+ENTRYPOINT [ "/dockerstartup/vnc_startup.sh" ]


### PR DESCRIPTION
This PR proposes adding a build for [Devuan Excalibur (6)](https://www.devuan.org/os/announce/excalibur-release-announce-2025-11-02), which itself is a fork of Debian Trixie (13).

The Docker images are adopted from the Trixie counterpart with minimal changes.