### PR TITLE
Remove leftover debug printf from EncodeManager::doUpdate

### DIFF
--- a/common/rfb/EncodeManager.cxx
+++ b/common/rfb/EncodeManager.cxx
@@ -476,7 +476,6 @@ void EncodeManager::doUpdate(bool allowLossy, const Region& changed_,
 
     updateQualities();
 
-    printf("TOTAL FRAME TOOK: %d\n", msSince(&start));
     conn->writer()->writeFramebufferUpdateEnd();
 }
 


### PR DESCRIPTION
`printf("TOTAL FRAME TOOK: %d\n", ...)` runs once per frame on every connection, spamming the kasmvncserver log/console with one line per encode. This appears to be a debug aid left in from the VNC-151 video encoding work.

No behavior change beyond removing the noise.