### PR TITLE
Drop avcodec_close for FFmpeg 8 compatibility

### DIFF
--- a/common/rfb/benchmark/FfmpegFrameFeeder.cpp
+++ b/common/rfb/benchmark/FfmpegFrameFeeder.cpp
@@ -22,9 +22,7 @@
 
 FfmpegFrameFeeder::FfmpegFrameFeeder(FFmpeg *ffmpeg_) : ffmpeg{ffmpeg_} {}
 
-FfmpegFrameFeeder::~FfmpegFrameFeeder() {
-    ffmpeg->avcodec_close(codec_ctx_guard.get());
-}
+FfmpegFrameFeeder::~FfmpegFrameFeeder() = default;
 
 void FfmpegFrameFeeder::open(const std::string_view path) {
     AVFormatContext *format_ctx{};

--- a/common/rfb/ffmpeg.cxx
+++ b/common/rfb/ffmpeg.cxx
@@ -117,7 +117,6 @@ FFmpeg::FFmpeg() {
         avcodec_receive_packet_f = D_LOOKUP_SYM(handle, avcodec_receive_packet);
         av_packet_unref_f = D_LOOKUP_SYM(handle, av_packet_unref);
         avcodec_flush_buffers_f = D_LOOKUP_SYM(handle, avcodec_flush_buffers);
-        avcodec_close_f = D_LOOKUP_SYM(handle, avcodec_close);
         av_codec_is_encoder_f = D_LOOKUP_SYM(handle, av_codec_is_encoder);
         av_packet_alloc_f = D_LOOKUP_SYM(handle, av_packet_alloc);
         av_packet_free_f = D_LOOKUP_SYM(handle, av_packet_free);

--- a/common/rfb/ffmpeg.h
+++ b/common/rfb/ffmpeg.h
@@ -135,7 +135,6 @@ class FFmpeg final {
     using avcodec_receive_frame_func = int (*)(AVCodecContext *avctx, AVFrame *frame);
     using av_packet_unref_func = void (*)(AVPacket *pkt);
     using avcodec_flush_buffers_func = void (*)(AVCodecContext *avctx);
-    using avcodec_close_func = int (*)(AVCodecContext *avctx);
     using av_codec_is_encoder_func = int (*)(const AVCodec *codec);
 
     struct DlHandler {
@@ -193,7 +192,6 @@ class FFmpeg final {
     avcodec_receive_packet_func avcodec_receive_packet_f{};
     av_packet_unref_func av_packet_unref_f{};
     avcodec_flush_buffers_func avcodec_flush_buffers_f{};
-    avcodec_close_func avcodec_close_f{};
     av_codec_is_encoder_func av_codec_is_encoder_f{};
 
     DlHandlerGuard libavformat{};
@@ -372,10 +370,6 @@ public:
 
     void avcodec_flush_buffers(AVCodecContext *avctx) const {
         avcodec_flush_buffers_f(avctx);
-    }
-
-    int avcodec_close(AVCodecContext *avctx) const {
-        return avcodec_close_f(avctx);
     }
 
     int av_codec_is_encoder(const AVCodec *codec) const {


### PR DESCRIPTION
  ## Problem

  On systems with FFmpeg 8.0+ (Arch as of late 2025/early 2026, recent
  Fedora, etc.), KasmVNC cannot initialize hardware video encoding. The
  log shows:

  ffmpeg: Failed to load symbol avcodec_close
  VNCServerST: Hardware video encoding acceleration capability: unavailable

  KasmVNC then silently falls back to its software WebP/JPEG encoders,
  which is a major regression for users who configured `videoCodec:
  h264_vaapi` (or similar) and are now paying significant CPU for
  something the hardware was meant to handle.

  ## Root cause

  `avcodec_close()` was deprecated in FFmpeg 3.x (its replacement,
  `avcodec_free_context()`, has existed since 2015) and was finally
  **removed in FFmpeg 8.0**.

  `FFmpeg::FFmpeg()` resolves every libavcodec symbol via the
  `D_LOOKUP_SYM` macro, which throws on any missing symbol. The
  constructor catches the throw and sets `available = false` —
  disabling the entire hardware-encode path. So the missing
  `avcodec_close` symbol kills hardware encoding wholesale, even though
  the encode path itself never calls `avcodec_close`.

  ## Why removing the symbol is safe

  `grep -rn 'avcodec_close'` over the tree shows only one production
  caller: the destructor of `FfmpegFrameFeeder` (a benchmarking helper
  for `Xvnc_replay_benchmark`):

  ```cpp
  FfmpegFrameFeeder::~FfmpegFrameFeeder() {
      ffmpeg->avcodec_close(codec_ctx_guard.get());
  }

  That call was already redundant. codec_ctx_guard is a
  FFmpeg::ContextGuard (a std::unique_ptr whose deleter calls
  avcodec_free_context). When the destructor returns, the
  unique_ptr is destroyed and avcodec_free_context runs — and
  avcodec_free_context internally already closes the codec before
  freeing the AVCodecContext. The explicit avcodec_close was a
  no-op in terms of correctness, and on FFmpeg 8 it's just impossible.

  The production VNC encode path uses the same guard pattern and
  therefore was already working correctly via avcodec_free_context;
  it never needed the avcodec_close shim.

  Change

  - Drop the avcodec_close_func typedef, member, dlsym, and wrapper
  method from common/rfb/ffmpeg.{h,cxx}.
  - Default the benchmark destructor (= default) — the unique_ptr
  guard handles cleanup, which is the modern idiomatic approach.

  Diff is 1 insertion, 10 deletions across 3 files. No behavior change
  on FFmpeg ≤ 7; restores hardware encode on FFmpeg ≥ 8.

  Verification

  Built against FFmpeg 8.1.1 on Arch (libavcodec 62.x).

  Before:
  ffmpeg: Failed to load symbol avcodec_close
  VNCServerST: Hardware video encoding acceleration capability: unavailable

  After:
  ffmpeg: libavutil.so loaded
  ffmpeg: libswscale.so loaded
  ffmpeg: libavcodec.so loaded
  VNCServerST: Hardware video encoding acceleration capability: h264_vaapi

  intel_gpu_top during a streamed-video session confirms the iGPU's
  VCS (Video) engine wakes from RC6 and stays active throughout the
  session, where previously it was a flat 0% across every sample.